### PR TITLE
[feat] New Etherpad script helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,27 @@ This repository contains files for many purposes.
 
 - [scripts](#scripts)
   - [detect changes](#detect_changes)
+  - [npm install in all plugins](#npm_install_in_all_plugins)
   - [tag plugins](#tag_plugins)
-  - [open vinagre (Linux only)](#open_vinagre)
+  - [update plugins to master](#update_plugins_to_master)
 
 # <a name="scripts"></a>Scripts
-
-**<a name="tag_plugins"></a>tag-plugins**
-
-Copy this script to `etherpad-docker/etherpad-src/etherpad-lite/node_modules` and run it to create a tag for each etherpad plugin.
-
-See [how to create tags](https://github.com/storytouch/web/wiki/%5BHow-To%5D-Create-tag-for-a-new-release)
 
 **<a name="detect_changes"></a>detect-changes**
 
 Copy this script to `etherpad-docker/etherpad-src/etherpad-lite/node_modules` and run it to check if all plugins are in the HEAD of the right branch.
 
 If it runs without errors, then the tag can be created.
+
+**<a name="npm_install_in_all_plugins"></a>npm-install-in-all-plugins**
+
+Copy this script to `etherpad-docker/etherpad-src/etherpad-lite/node_modules` and run it to install the node packages required for each plugin.
+
+**<a name="tag_plugins"></a>tag-plugins**
+
+Copy this script to `etherpad-docker/etherpad-src/etherpad-lite/node_modules` and run it to create a tag for each etherpad plugin.
+
+See [how to create tags](https://github.com/storytouch/web/wiki/%5BHow-To%5D-Create-tag-for-a-new-release)
 
 **<a name="open_vinagre"></a>open-vinagre**
 
@@ -27,3 +32,7 @@ This script is only for users running on **Linux**.
 Execute this script to open Vinagre VNC to connect to chrome containers when running integration tests locally.
 
 When you are prompted for the **password**, it is **secret**, as specified in the "docker-selenium" github page,
+
+**<a name="update_plugins_to_master"></a>update-plugins-to-master**
+
+Copy this script to `etherpad-docker/etherpad-src/etherpad-lite/node_modules` and run it to change the git branch of all plugins to `master` (there are some special cases).

--- a/scripts/npm-install-in-all-plugins.sh
+++ b/scripts/npm-install-in-all-plugins.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+for dir in * ; do
+  if [[ -d $dir  ]] &&  [[ -d $dir/.git ]]; then
+    (
+      echo $dir
+
+      # enters in the plugin's directory
+      cd $dir
+
+      # instal node packages
+      npm install
+    );
+  fi
+done

--- a/scripts/update-plugins-to-master.sh
+++ b/scripts/update-plugins-to-master.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+for dir in * ; do
+  if [[ -d $dir  ]] &&  [[ -d $dir/.git ]]; then
+    (
+      echo ""
+      echo $dir
+
+      # enters in the plugin's directory
+      cd $dir
+
+      # fetch changes in all branches
+      git fetch --all --prune
+
+      # some plugins do not use master as default branch,
+      # so make sure to checkout the right branch
+      if [[ $dir == "ep_comments_page" ]]; then
+        git checkout master-tk
+      elif [[ $dir == "ep_googleanalytics" ]]; then
+        git checkout upgrade_to_universal_analytics2
+      else
+        git checkout master
+      fi
+
+      # pull changes from remote branch
+      git pull
+
+      echo ""
+    );
+  fi
+done


### PR DESCRIPTION
This PR adds two new scripts related to Etherpad plugins
1. `npm-install-in-all-plugins.sh`: runs `npm install` in all Etherpad plugins
2. `update-all-plugins-to-master.sh`: changes the git branch of all Etherpad plugins to `master`