### PR TITLE
[feat] Add script to run test cases repeatedly

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This repository contains files for many purposes.
 - [scripts](#scripts)
   - [detect changes](#detect_changes)
   - [npm install in all plugins](#npm_install_in_all_plugins)
+  - [run many times](#run_many_times)
   - [tag plugins](#tag_plugins)
   - [update plugins to master](#update_plugins_to_master)
-  - [run many times](#run_many_times)
 
 # <a name="scripts"></a>Scripts
 
@@ -19,6 +19,17 @@ If it runs without errors, then the tag can be created.
 **<a name="npm_install_in_all_plugins"></a>npm-install-in-all-plugins**
 
 Copy this script to `etherpad-docker/etherpad-src/etherpad-lite/node_modules` and run it to install the node packages required for each plugin.
+
+**<a name="run_many_times"></a>run_many_times**
+
+Copy this script to `web/react-webpack/test` and execute it to run a command repeatedly and to show how many times it has succed or failed.  It's useful to verify instability in automated tests. You should run it inside `webpack` container. Usage example:
+```bash
+# enter webpack container bash
+docker-compose exec webpack /bin/bash
+
+# run help.spec.js test case 5 times
+./test/run_many_times.sh 'yarn test:integration:singleuser:single test/integration/home/help.spec.js' 5
+```
 
 **<a name="tag_plugins"></a>tag-plugins**
 
@@ -37,14 +48,3 @@ When you are prompted for the **password**, it is **secret**, as specified in th
 **<a name="update_plugins_to_master"></a>update-plugins-to-master**
 
 Copy this script to `etherpad-docker/etherpad-src/etherpad-lite/node_modules` and run it to change the git branch of all plugins to `master` (there are some special cases).
-
-**<a name="run_many_times"></a>run_many_times**
-
-Copy this script to `web/react-webpack/test` and execute it to run a command repeatedly and to show how many times it has succed or failed.  It's useful to verify instability in automated tests. You should run it inside `webpack` container. Usage example:
-```bash
-# enter webpack container bash
-docker-compose exec webpack /bin/bash
-
-# run help.spec.js test case 5 times
-./test/run_many_times.sh 'yarn test:integration:singleuser:single test/integration/home/help.spec.js' 5
-```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains files for many purposes.
   - [npm install in all plugins](#npm_install_in_all_plugins)
   - [tag plugins](#tag_plugins)
   - [update plugins to master](#update_plugins_to_master)
+  - [run many times](#run_many_times)
 
 # <a name="scripts"></a>Scripts
 
@@ -36,3 +37,14 @@ When you are prompted for the **password**, it is **secret**, as specified in th
 **<a name="update_plugins_to_master"></a>update-plugins-to-master**
 
 Copy this script to `etherpad-docker/etherpad-src/etherpad-lite/node_modules` and run it to change the git branch of all plugins to `master` (there are some special cases).
+
+**<a name="run_many_times"></a>run_many_times**
+
+Copy this script to `web/react-webpack/test` and execute it to run a command repeatedly and to show how many times it has succed or failed.  It's useful to verify instability in automated tests. You should run it inside `webpack` container. Usage example:
+```bash
+# enter webpack container bash
+docker-compose exec webpack /bin/bash
+
+# run help.spec.js test case 5 times
+./test/run_many_times.sh 'yarn test:integration:singleuser:single test/integration/home/help.spec.js' 5
+```

--- a/scripts/run_many_times.sh
+++ b/scripts/run_many_times.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This script runs a command repeatedly and prints how many times
+# it has succed and failed. Useful to verify instability in automated tests.
+#
+# The following example runs the command `your_command` with a parameter five times.
+#
+# ./scripts/run_many_times.sh 'your_command --parameter="param"' 5
+
+# Declare variables to count how many times the test passed or failed.
+pass=0
+fail=0
+
+# Runs the loop
+for execution in $(seq $2); do
+  # Execute given command
+  $1
+
+  # Verifies the command execution result
+  if [ "$?" -eq 0 ]
+  then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+  fi
+done
+
+echo "
+PASS: $pass
+FAIL: $fail
+RUNS: $execution"


### PR DESCRIPTION
This PR adds `run_many_times.sh` script, which allow us to run a command repeatedly and show how many times it has succeed or failed.  It's useful to verify instability in automated tests.

Complements [card #2853](https://trello.com/c/jq1lv2DX).